### PR TITLE
update emscripten

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM trzeci/emscripten@sha256:65c7bfc84c38f2f5d11d36296a715e0c5e3c36f58a08d9ef3dfc74425d05e860
+FROM trzeci/emscripten:sdk-tag-1.38.6-64bit
 # the latest trzeci/emscripten produces binaries that do not work
 # trzeci/emscripten:sdk-tag-1.38.6-64bit is the sha above
 


### PR DESCRIPTION
The latest docker file for emscripten did not produce a webassembly of imagemagick that passed tests.

Using CI to find last version that works