### PR TITLE
prevent runtimeerror on untrap math operations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ export CPPFLAGS="-I/code/libpng -I/code/zlib -I/code/libjpeg -I/code/libtiff/lib
 export LDFLAGS="-L/code/zlib -L/code/libpng -L/code/libpng/.libs -L/code/libjpeg -L/code/libtiff/libtiff"
 export CFLAGS="-O3"
 export CXXFLAGS="$CFLAGS"
-MAKE_FLAGS="-s ALLOW_MEMORY_GROWTH=1"
+MAKE_FLAGS="-s BINARYEN_TRAP_MODE=clamp -s ALLOW_MEMORY_GROWTH=1"
 
 export PKG_CONFIG_PATH="/code/libpng:/code/zlib:/code/libjpeg:/code/libtiff:/code/libtiff/libtiff:"
 export PNG_LIBS="-L/code/libpng -L/code/libpng/.libs"


### PR DESCRIPTION
Adding `BINARYEN_TRAP_MODE=clamp` as documented here: https://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#trap-mode  seems to solve 
https://github.com/KnicKnic/WASM-ImageMagick/issues/12