### PR TITLE
determine referenced paths automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,8 @@
 ## 1.2.1
 
  * First automated release
+
+## 1.2.2
+
+ * Support auto discovery of magick.js & magick.wasm files
+   * Allows simple usage in CDNs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-imagemagick",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2737,6 +2737,14 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+      "integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+      "requires": {
+        "stackframe": "^1.0.4"
       }
     },
     "es5-ext": {
@@ -7849,11 +7857,50 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-generator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
+      "integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
+      "requires": {
+        "stackframe": "^1.0.4"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
+    },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
+      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.0.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
+      "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
+      "requires": {
+        "error-stack-parser": "^2.0.1",
+        "stack-generator": "^2.0.1",
+        "stacktrace-gps": "^3.0.1"
+      }
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bundle": "npx tsc --project tsconfig-esm5.json && npx tsc --project tsconfig-esm6.json && npx tsc --project tsconfig-esm2018.json && mkdir -p dist/bundles && npx rollup -c rollup.config.js && npx rollup -c rollup.config.js --environment NODE_ENV:production",
     "build": "npm run build-wasm && npm run build-ts",
     "prepare": "npm run build && npm run copy && npm run magickApiJs",
-    "copy": "npm run copy-magickJs && npm run copy-magickWasm && mkdir -p dist && cp magick.js magick.wasm dist && cp magick.js magick.wasm spec/assets && cp -r spec/assets dist",
+    "copy": "npm run copy-magickJs && npm run copy-magickWasm && mkdir -p dist && cp magick.js magick.wasm dist && mkdir -p dist/bundles && cp magick.js magick.wasm dist/bundles && cp magick.js magick.wasm spec/assets && cp -r spec/assets dist",
     "copy-magickJs": "rm -rf magick.js && cp webworker.js magick.js && cat ImageMagick/utilities/magick.js >> magick.js",
     "copy-magickWasm": "rm -rf magick.wasm && cp ImageMagick/utilities/magick.wasm .",
     "magickApiJs": "cp dist/bundles/wasm-imagemagick.esm-es6.js magickApi.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-imagemagick",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Webassembly compilation of ImageMagick",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
@@ -20,7 +20,7 @@
     "lint-and-fix": "tslint \"src/**/*.ts\" \"spec/**/*.ts\" --fix",
     "generateImEnums": "npx ts-node scripts/generateImEnums.ts",
     "test": "npm run test-node && npm run test-browser",
-    "test-node-prepare":  "cp tests/rotate/node_header.js tests/rotate/node.js && cat ImageMagick/utilities/magick.js >> tests/rotate/node.js && cp magick.wasm tests/rotate",
+    "test-node-prepare": "cp tests/rotate/node_header.js tests/rotate/node.js && cat ImageMagick/utilities/magick.js >> tests/rotate/node.js && cp magick.wasm tests/rotate",
     "test-node": "npm run test-node-prepare && cd tests/rotate && node node",
     "test-browser-build": "tsc && browserify -d dist/spec/index.js -o dist/bundle.js",
     "test-browser": "rm -rf dist && npm run test-browser-build  &&  npm run copy && gulp --gulpfile spec/gulpfile.js jasmine",
@@ -83,6 +83,7 @@
     "webpack-config-utils": "^2.3.1"
   },
   "dependencies": {
-    "p-map": "^2.0.0"
+    "p-map": "^2.0.0",
+    "stacktrace-js": "^2.0.0"
   }
 }

--- a/src/magickApi.ts
+++ b/src/magickApi.ts
@@ -1,3 +1,4 @@
+import StackTrace from "stacktrace-js"
 /**
  * Base class for ImageMagick input and output files.
  */
@@ -92,13 +93,26 @@ function GetCurrentUrlDifferentFilename(fileName)
     return ChangeUrl(currentJavascriptURL, fileName)
 }
 let currentJavascriptURL = './magickApi.js';
-try {
-    // @ts-ignore
-    let packageUrl = import.meta.url;
-    currentJavascriptURL = packageUrl;
-} catch (error) {
-    // eat
+
+// // instead of doing the sane code of being able to just use import.meta.url 
+// // (Edge doesn't work) (safari mobile, chrome, opera, firefox all do)
+// // 
+// // I will use stacktrace-js library to get the current file name
+// //
+// try {
+//   // @ts-ignore
+//   let packageUrl = import.meta.url;
+//   currentJavascriptURL = packageUrl;
+// } catch (error) {
+//   // eat
+// }
+//
+//
+{
+  let stacktrace = StackTrace.getSync();
+  currentJavascriptURL = stacktrace[0].fileName;
 }
+
 const magickWorkerUrl = GetCurrentUrlDifferentFilename('magick.js')
 
 function GenerateMagickWorkerText(magickUrl){
@@ -109,8 +123,14 @@ function GenerateMagickWorkerText(magickUrl){
   return "var magickJsCurrentPath = '" + magickUrl +"';\n" +
          'importScripts(magickJsCurrentPath);'
 }
-
-const magickWorker = new Worker(window.URL.createObjectURL(new Blob([GenerateMagickWorkerText(magickWorkerUrl)])));
+let magickWorker;
+if(currentJavascriptURL.startsWith('http'))
+{
+    magickWorker = new Worker(window.URL.createObjectURL(new Blob([GenerateMagickWorkerText(magickWorkerUrl)])));
+}
+else{
+    magickWorker = new Worker(magickWorkerUrl);
+}
 
 const magickWorkerPromises = {}
 let magickWorkerPromisesKey = 1

--- a/src/magickApi.ts
+++ b/src/magickApi.ts
@@ -80,7 +80,37 @@ function CreatePromiseEvent() {
   return emptyPromise
 }
 
-const magickWorker = new Worker('magick.js')
+
+function ChangeUrl(url, fileName)
+{
+    let splitUrl = url.split('/')
+    splitUrl[splitUrl.length -1] = fileName
+    return splitUrl.join('/')
+}
+function GetCurrentUrlDifferentFilename(fileName)
+{
+    return ChangeUrl(currentJavascriptURL, fileName)
+}
+let currentJavascriptURL = './magickApi.js';
+try {
+    // @ts-ignore
+    let packageUrl = import.meta.url;
+    currentJavascriptURL = packageUrl;
+} catch (error) {
+    // eat
+}
+const magickWorkerUrl = GetCurrentUrlDifferentFilename('magick.js')
+
+function GenerateMagickWorkerText(magickUrl){
+  // generates code for the following
+  // var magickJsCurrentPath = 'magickUrl';
+  // importScripts(magickJsCurrentPath);
+
+  return "var magickJsCurrentPath = '" + magickUrl +"';\n" +
+         'importScripts(magickJsCurrentPath);'
+}
+
+const magickWorker = new Worker(window.URL.createObjectURL(new Blob([GenerateMagickWorkerText(magickWorkerUrl)])));
 
 const magickWorkerPromises = {}
 let magickWorkerPromisesKey = 1

--- a/webworker.js
+++ b/webworker.js
@@ -4,6 +4,19 @@ const stdout = []
 const stderr = []
 let exitCode = 0
 
+
+function ChangeUrl(url, fileName)
+{
+    let splitUrl = url.split('/')
+    splitUrl[splitUrl.length -1] = fileName
+    return splitUrl.join('/')
+}
+// const magickJsCurrentPath = 'https://knicknic.github.io/wasm-imagemagick/magick.js';
+function GetCurrentUrlDifferentFilename(fileName)
+{
+    return ChangeUrl(magickJsCurrentPath, fileName)
+}
+
 if (typeof Module == 'undefined') {
   Module = {
     noInitialRun: true,
@@ -21,6 +34,9 @@ if (typeof Module == 'undefined') {
     quit: status=> {
       exitCode = status
     }
+  }
+  if(magickJsCurrentPath !== undefined){
+      Module.locateFile = GetCurrentUrlDifferentFilename;
   }
 
   // see https://kripken.github.io/emscripten-site/docs/api_reference/module.html

--- a/webworker.js
+++ b/webworker.js
@@ -35,7 +35,7 @@ if (typeof Module == 'undefined') {
       exitCode = status
     }
   }
-  if(magickJsCurrentPath !== undefined){
+  if(typeof magickJsCurrentPath !== "undefined"){
       Module.locateFile = GetCurrentUrlDifferentFilename;
   }
 


### PR DESCRIPTION
Attempts to allow external referencing of magick.

It does so by declaring the webworker in the context of the current page as webworkers cannot be in a remote origin.

It updates the loading of the wasm file to be based on a specified path.

Due to Edge not working with import.meta.url, I use stacktrace-js to get the current file location. 

Also I added magick.js and magick.wasm into the bundles folder to make it easier for those programs to grab the code. This now means that magick.js and magick.wasm should be placed into wherever the bundled source code comes from.... I could reference it based on the bundles folder to something like ../assets if that is a better thing. I would like your guidance @cancerberoSgx .
