### PR TITLE
Fix path to worker

### DIFF
--- a/src/magickApi.ts
+++ b/src/magickApi.ts
@@ -127,6 +127,9 @@ let currentJavascriptURL = './magickApi.js';
 //
 {
   let stacktrace = StackTrace.getSync();
+  // Pulling the filename from the 3rd callsite of the stacktrace to get the full path
+  // to the module. The first index is inconsitent across browsers and does not return 
+  // the full path in Safari and resuls in the worker failing to reslolve. 
   currentJavascriptURL = stacktrace[2].fileName;
 }
 

--- a/src/magickApi.ts
+++ b/src/magickApi.ts
@@ -111,7 +111,26 @@ function GetCurrentUrlDifferentFilename(fileName)
 }
 let currentJavascriptURL = './magickApi.js';
 
-const magickWorkerUrl = './magick.js';
+// // instead of doing the sane code of being able to just use import.meta.url 
+// // (Edge doesn't work) (safari mobile, chrome, opera, firefox all do)
+// // 
+// // I will use stacktrace-js library to get the current file name
+// //
+// try {
+//   // @ts-ignore
+//   let packageUrl = import.meta.url;
+//   currentJavascriptURL = packageUrl;
+// } catch (error) {
+//   // eat
+// }
+//
+//
+{
+  let stacktrace = StackTrace.getSync();
+  currentJavascriptURL = stacktrace[2].fileName;
+}
+
+const magickWorkerUrl = GetCurrentUrlDifferentFilename('magick.js')
 
 function GenerateMagickWorkerText(magickUrl){
   // generates code for the following


### PR DESCRIPTION
This fixes the path to the worker in Safari by getting the filename from the correct `Stacktrace`

Safari
![image](https://user-images.githubusercontent.com/399068/73809898-e5d51b00-4791-11ea-8651-058bf009724f.png)


Chrome
In chrome you get the full path 
![image](https://user-images.githubusercontent.com/399068/73810006-48c6b200-4792-11ea-8e2e-356354ec4852.png)


