### PR TITLE
Fix FS stream leak

### DIFF
--- a/webworker.js
+++ b/webworker.js
@@ -22,13 +22,13 @@ if (typeof Module == 'undefined') {
     moduleLoaded: false,
     messagesToProcess: [],
 
-    print: text => { 
-      stdout.push(text) 
-      console.log(text)      
+    print: text => {
+      stdout.push(text)
+      console.log(text)
     },
-    printErr: text => { 
+    printErr: text => {
       stderr.push(text)
-      console.error(text);      
+      console.error(text);
     },
     quit: status=> {
       exitCode = status
@@ -91,7 +91,7 @@ processFiles = function () {
       let read = FS.readFile(destFilename)
       // cleanup read file
       FS.unlink(destFilename)
-            
+
       if('transferable' in message)
       {
         processed.buffer = read
@@ -117,6 +117,7 @@ processFiles = function () {
         transfer.push(file.content.buffer)
       }
     }
+    FS.close(dir);
     postMessage(message) //, transfer)
   }
   Module.messagesToProcess = []


### PR DESCRIPTION
Each time we call `processFiles` it opens a new file handler for `/pictures` directory and never closes it. As a result, these handlers accumulate and processing fails when reaching the `FS` limit (4096 streams).
Related issue: https://github.com/KnicKnic/WASM-ImageMagick/issues/140

P.S. Sorry for the irrelevant formatting changes.